### PR TITLE
export all public types for proper Typescript use

### DIFF
--- a/src/helphero.ts
+++ b/src/helphero.ts
@@ -108,3 +108,5 @@ export default function initHelpHero(appId: string): HelpHero {
   });
   return instance;
 }
+
+export { Data, Event, EventInfo, EventKind, HelpHero, Step, Tour };


### PR DESCRIPTION
I suspect that adding `export` in front of of the type definition for HelpHero will result in 
`export type HelpHero` in the .d.ts file that is distributed with the npm module.  However, I cannot actually verify this at the moment because I am having trouble building the helphero-javascript project locally.  See #4 .  I have found that the .d.ts file needs the `export` in front of the HelpHero type in order to be used in my Angular Typescript project.  When I make this change in the dist/helphero.d.ts file from your npm module manually, then the TSC is happy.  Without the export, I get a red squiggle.  @Andrewdt97 and I have copy/pasted the HelpHero type part of the helphero.d.ts file to our own type file to make our project build, but I'd rather have your npm module work out of the box, which is what this PR attempts to do.